### PR TITLE
Ignore node_modules and package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+node_modules/
+package-lock.json


### PR DESCRIPTION
Add node_modules and package-lock.json into .gitignore so that I don't commit huge files by mistake.