### PR TITLE
parse tx.receipt.status into true

### DIFF
--- a/test/enssec.js
+++ b/test/enssec.js
@@ -37,7 +37,7 @@ const test_rrsets = [
 async function verifySubmission(instance, name, data, sig) {
   var name = dns.hexEncodeName(name);
   var tx = await instance.submitRRSet(1, name, data, sig);
-  assert.equal(tx.receipt.status, "0x1");
+  assert.equal(parseInt(tx.receipt.status), parseInt('0x1'));
   assert.equal(tx.logs.length, 1);
   assert.equal(tx.logs[0].args.name, name);
   return tx;


### PR DESCRIPTION
At Truffle 4.1.0, `tx.receipt.status` is changed from `true` to `0x01` while the test was checking against '0x1'.
The type of the value are inconsistent among different documentaition so decide to compare converted integer.

- [Web3 1.0](https://web3js.readthedocs.io/en/1.0/web3-eth.html?highlight=receipt#eth-gettransactionreceipt-return)  sates 'true' indicates transaction succeeded
- [old Web3 wiki](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransactionreceipt) sates '0x1' indicates transaction succeeded

This fix should now fix the following tests.

```
    ✓ should accept a root DNSKEY (315ms)
    ✓ should support wildcard subdomains (148ms)
    ✓ should accept updates with newer signatures (148ms)
```