### PR TITLE
Reuse dns js

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -177,3 +177,46 @@ var hexEncodeSignedSet = exports.hexEncodeSignedSet = function(rec) {
   var off = encodeSignedSet(buf, 0, rec);
   return "0x" + buf.toString("hex", 0, off);
 }
+
+var encodeAnchors = exports.encodeAnchors = function(anchors) {
+  var buf = new Buffer(4096);
+  var off = 0;
+  for(var anchor of anchors) {
+    off = encodeDS(buf, off, anchor);
+  }
+  return "0x" + buf.toString("hex", 0, off);
+}
+
+var anchors = exports.anchors = [
+  {
+    name: ".",
+    type: TYPE_DS,
+    klass: CLASS_INET,
+    ttl: 3600,
+    keytag: 19036,
+    algorithm: 8,
+    digestType: 2,
+    digest: new Buffer("49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5", "hex")
+  },
+  {
+    name: ".",
+    type: TYPE_DS,
+    klass: CLASS_INET,
+    ttl: 3600,
+    keytag: 20326,
+    algorithm: 8,
+    digestType: 2,
+    digest: new Buffer("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", "hex")
+  },
+];
+
+var dummyAnchor = exports.dummyAnchor = {
+  name: ".",
+  type: TYPE_DS,
+  klass: CLASS_INET,
+  ttl: 3600,
+  keytag: 5647, // Empty body, flags == 0x0101, algorithm = 253, body = 0x1111
+  algorithm: 253,
+  digestType: 253,
+  digest: new Buffer("", "hex")
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,53 +9,15 @@ var dummydigest = artifacts.require("./DummyDigest.sol");
 
 var dns = require("../lib/dns.js");
 
-function encodeAnchors(anchors) {
-  var buf = new Buffer(4096);
-  var off = 0;
-  for(var anchor of anchors) {
-    off = dns.encodeDS(buf, off, anchor);
-  }
-  return "0x" + buf.toString("hex", 0, off);
-}
-
 module.exports = function(deployer, network) {
   var dev = (network == "test" || network == "local");
   // From http://data.iana.org/root-anchors/root-anchors.xml
-  var anchors = [
-    {
-      name: ".",
-      type: dns.TYPE_DS,
-      klass: dns.CLASS_INET,
-      ttl: 3600,
-      keytag: 19036,
-      algorithm: 8,
-      digestType: 2,
-      digest: new Buffer("49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5", "hex")
-    },
-    {
-      name: ".",
-      type: dns.TYPE_DS,
-      klass: dns.CLASS_INET,
-      ttl: 3600,
-      keytag: 20326,
-      algorithm: 8,
-      digestType: 2,
-      digest: new Buffer("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", "hex")
-    },
-  ];
+  var anchors = dns.anchors;
+
   if(dev) {
-    anchors.push({
-      name: ".",
-      type: dns.TYPE_DS,
-      klass: dns.CLASS_INET,
-      ttl: 3600,
-      keytag: 5647, // Empty body, flags == 0x0101, algorithm = 253, body = 0x1111
-      algorithm: 253,
-      digestType: 253,
-      digest: new Buffer("", "hex")
-    });
+    anchors.push(dns.dummyAnchor);
   }
-  return deployer.deploy(dnssec, encodeAnchors(anchors))
+  return deployer.deploy(dnssec, dns.encodeAnchors(anchors))
     .then(() => deployer.deploy([[rsasha256], [rsasha1], [sha256], [sha1], [nsec3sha1]]))
     .then(() => dev?deployer.deploy([[dummyalgorithm], [dummydigest]]):null)
     .then(() => dnssec.deployed().then(function(instance) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1981,7 +1981,7 @@
         "jsonfile": "2.4.0",
         "klaw": "1.3.1",
         "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "rimraf": "2.6.2"
       }
     },
     "fs.realpath": {
@@ -4871,10 +4871,13 @@
       }
     },
     "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -5126,9 +5129,9 @@
       "dev": true
     },
     "solc": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
-      "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
+      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
       "dev": true,
       "requires": {
         "fs-extra": "0.30.0",
@@ -5161,16 +5164,6 @@
             "wrap-ansi": "2.1.0"
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5180,19 +5173,6 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
         "os-locale": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -5200,62 +5180,6 @@
           "dev": true,
           "requires": {
             "lcid": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -5725,95 +5649,14 @@
       "dev": true
     },
     "truffle": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.7.tgz",
-      "integrity": "sha512-fe6BIcD9xo6iIJvV1m6ZhOk56kmB8k38kdoWOKYnPPw7ZUUSupgojeTb2K5e+4qIpIHvEvmET4yLUjSGR+hvwA==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.12.tgz",
+      "integrity": "sha1-9F9LbBzhWGX817v19jNA9eFuKVA=",
       "dev": true,
       "requires": {
-        "mocha": "3.5.3",
+        "mocha": "4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.4.23"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "growl": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "mocha": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-          "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-          "dev": true,
-          "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.9.0",
-            "debug": "2.6.8",
-            "diff": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.1",
-            "growl": "1.9.2",
-            "he": "1.1.1",
-            "json3": "3.3.2",
-            "lodash.create": "3.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "3.1.2"
-          }
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
+        "solc": "0.4.24"
       }
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "truffle test",
     "watch": "npm-watch",
     "lint": "solium --dir ./contracts",
-    "prepublishOnly": "truffle networks --clean && truffle compile"
+    "prepublishOnly": "truffle migrate && truffle networks --clean"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnssec-oracle",
+  "name": "@ensdomains/dnssec-oracle",
   "version": "0.0.1",
   "requires": true,
   "lockfileVersion": 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnssec-oracle",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "requires": true,
   "lockfileVersion": 1,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ensdomains/dnssec-oracle",
+  "name": "dnssec-oracle",
   "version": "0.0.1",
   "requires": true,
   "lockfileVersion": 1,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "truffle test",
     "watch": "npm-watch",
     "lint": "solium --dir ./contracts",
-    "prepublishOnly": "truffle migrate && truffle networks --clean"
+    "prepublishOnly": "truffle compile && truffle networks --clean"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eth-gas-reporter": "^0.1.2",
     "rfc4648": "^1.1.0",
     "solium": "^1.0.4",
-    "truffle": "^4.0.0"
+    "truffle": "^4.1.12"
   },
   "scripts": {
     "pretest": "truffle compile",


### PR DESCRIPTION
This change include the followings.

- Move some functions from migration file to lib/dns.js so that other repos can reuse
- Upgrade truffle
- Fix prepublishOnly

@decanus Please publish to npm once merged