### PR TITLE
Bump up version to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnssec-oracle",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "requires": true,
   "lockfileVersion": 1,
   "devDependencies": {


### PR DESCRIPTION
This is the version currently deployed to the mainnet. I will tag it to 0.0.7 once merged