### PR TITLE
Replace insertion timestamp with expiration

### DIFF
--- a/contracts/DNSSEC.sol
+++ b/contracts/DNSSEC.sol
@@ -19,5 +19,5 @@ abstract contract DNSSEC {
     function submitRRSet(RRSetWithSignature calldata input, bytes calldata proof) public virtual returns (bytes memory);
     function deleteRRSet(uint16 deleteType, bytes calldata deleteName, RRSetWithSignature calldata nsec, bytes calldata proof) public virtual;
     function deleteRRSetNSEC3(uint16 deleteType, bytes memory deleteName, RRSetWithSignature memory closestEncloser, RRSetWithSignature memory nextClosest, bytes memory dnskey) public virtual;
-    function rrdata(uint16 dnstype, bytes calldata name) external virtual view returns (uint32, uint64, bytes20);
+    function rrdata(uint16 dnstype, bytes calldata name) external virtual view returns (uint32, uint32, bytes20);
 }

--- a/contracts/RRUtils.sol
+++ b/contracts/RRUtils.sol
@@ -332,7 +332,7 @@ library RRUtils {
     /**
      * @dev Compares two serial numbers using RFC1982 serial number math.
      */
-    function serialNumberGt(uint i1, uint i2) internal pure returns(bool) {
+    function serialNumberGte(uint i1, uint i2) internal pure returns(bool) {
         return int32(i1 - i2) >= 0;
     }
 

--- a/contracts/RRUtils.sol
+++ b/contracts/RRUtils.sol
@@ -329,6 +329,13 @@ library RRUtils {
         return self.compare(prevoff + 1, self.readUint8(prevoff), other, otherprevoff + 1, other.readUint8(otherprevoff));
     }
 
+    /**
+     * @dev Compares two serial numbers using RFC1982 serial number math.
+     */
+    function serialNumberGt(uint i1, uint i2) internal pure returns(bool) {
+        return int32(i1 - i2) >= 0;
+    }
+
     function progress(bytes memory body, uint off) internal pure returns(uint) {
         return off + 1 + body.readUint8(off);
     }

--- a/test/TestRRUtils.sol
+++ b/test/TestRRUtils.sol
@@ -100,10 +100,10 @@ contract TestRRUtils {
   }
 
   function testSerialNumberGt() public pure {
-    require(RRUtils.serialNumberGt(1, 0), "1 > 0");
-    require(!RRUtils.serialNumberGt(0, 1), "!(0 < 1)");
-    require(RRUtils.serialNumberGt(0, 0xFFFFFFFF), "0 > 0xFFFFFFFF");
-    require(!RRUtils.serialNumberGt(0xFFFFFFFF, 0), "!(0 < 0xFFFFFFFF)");
-    require(RRUtils.serialNumberGt(0x11111111, 0xAAAAAAAA), "0x11111111 > 0xAAAAAAAA");
+    require(RRUtils.serialNumberGte(1, 0), "1 >= 0");
+    require(!RRUtils.serialNumberGte(0, 1), "!(0 <= 1)");
+    require(RRUtils.serialNumberGte(0, 0xFFFFFFFF), "0 > 0xFFFFFFFF");
+    require(!RRUtils.serialNumberGte(0xFFFFFFFF, 0), "!(0 < 0xFFFFFFFF)");
+    require(RRUtils.serialNumberGte(0x11111111, 0xAAAAAAAA), "0x11111111 > 0xAAAAAAAA");
   }
 }

--- a/test/TestRRUtils.sol
+++ b/test/TestRRUtils.sol
@@ -102,8 +102,9 @@ contract TestRRUtils {
   function testSerialNumberGt() public pure {
     require(RRUtils.serialNumberGte(1, 0), "1 >= 0");
     require(!RRUtils.serialNumberGte(0, 1), "!(0 <= 1)");
-    require(RRUtils.serialNumberGte(0, 0xFFFFFFFF), "0 > 0xFFFFFFFF");
-    require(!RRUtils.serialNumberGte(0xFFFFFFFF, 0), "!(0 < 0xFFFFFFFF)");
-    require(RRUtils.serialNumberGte(0x11111111, 0xAAAAAAAA), "0x11111111 > 0xAAAAAAAA");
+    require(RRUtils.serialNumberGte(0, 0xFFFFFFFF), "0 >= 0xFFFFFFFF");
+    require(!RRUtils.serialNumberGte(0xFFFFFFFF, 0), "!(0 <= 0xFFFFFFFF)");
+    require(RRUtils.serialNumberGte(0x11111111, 0xAAAAAAAA), "0x11111111 >= 0xAAAAAAAA");
+    require(RRUtils.serialNumberGte(1, 1), "1 >= 1");
   }
 }

--- a/test/TestRRUtils.sol
+++ b/test/TestRRUtils.sol
@@ -99,4 +99,11 @@ contract TestRRUtils {
     require(bthLabXyz.compareNames(xyz)       >  0, "bthLab.xyz comes after xyz");
   }
 
+  function testSerialNumberGt() public pure {
+    require(RRUtils.serialNumberGt(1, 0), "1 > 0");
+    require(!RRUtils.serialNumberGt(0, 1), "!(0 < 1)");
+    require(RRUtils.serialNumberGt(0, 0xFFFFFFFF), "0 > 0xFFFFFFFF");
+    require(!RRUtils.serialNumberGt(0xFFFFFFFF, 0), "!(0 < 0xFFFFFFFF)");
+    require(RRUtils.serialNumberGt(0x11111111, 0xAAAAAAAA), "0x11111111 > 0xAAAAAAAA");
+  }
 }


### PR DESCRIPTION
This will allow us to keep records longer - until the signature they were submitted with expires - and therefore reduce wasted gas resubmitting the same records with the same signature.